### PR TITLE
RDKB-60146 : WAN Interface control Rbus methods

### DIFF
--- a/source/WanManager/wanmgr_policy_auto_impl.c
+++ b/source/WanManager/wanmgr_policy_auto_impl.c
@@ -1293,8 +1293,8 @@ static WcAwPolicyState_t State_WanInterfaceActive (WanMgr_Policy_Controller_t * 
             {
                 if(p_VirtIf->Enable == TRUE && p_VirtIf->Interface_SM_Running == FALSE)
                 {
-                    CcspTraceInfo(("%s %d Starting virtual InterfaceStateMachine for %d \n", __FUNCTION__, __LINE__, VirtId));
-                    if(WanMgr_StartWanVISM(pWanController->activeInterfaceIdx, WAN_IFACE_SELECTED) != 0)
+                    CcspTraceInfo(("%s %d: Starting virtual InterfaceStateMachine for %d, Selection.Status=%d\n", __FUNCTION__, __LINE__, VirtId, pActiveInterface->Selection.Status));
+                    if(WanMgr_StartWanVISM(pWanController->activeInterfaceIdx, (pActiveInterface->Selection.Status == WAN_IFACE_ACTIVE )?WAN_IFACE_ACTIVE:WAN_IFACE_SELECTED) != 0)
                     {
                         CcspTraceError(("%s %d: Failed to start WAN for interface %d \n", __FUNCTION__, __LINE__, pWanController->activeInterfaceIdx));
                         return STATE_AUTO_WAN_ERROR;

--- a/source/WanManager/wanmgr_policy_parallel_scan_impl.c
+++ b/source/WanManager/wanmgr_policy_parallel_scan_impl.c
@@ -502,7 +502,9 @@ static WcPsPolicyState_t Transition_SelectedInterfaceUp (WanMgr_Policy_Controlle
         return STATE_PARALLEL_SCAN_POLICY_ERROR;
     }
 
-    if(WanMgr_StartWanVISM(pWanController->activeInterfaceIdx, WAN_IFACE_SELECTED) != 0)
+    DML_WAN_IFACE * pActiveInterface = &(pWanController->pWanActiveIfaceData->data);
+    CcspTraceInfo(("%s %d: Starting  InterfaceStateMachine Selection.Status=%d\n", __FUNCTION__, __LINE__,  pActiveInterface->Selection.Status));
+    if(WanMgr_StartWanVISM(pWanController->activeInterfaceIdx, (pActiveInterface->Selection.Status == WAN_IFACE_ACTIVE )?WAN_IFACE_ACTIVE:WAN_IFACE_SELECTED) != 0)
     {
         CcspTraceError(("%s %d: Failed to start WAN for interface %d \n", __FUNCTION__, __LINE__, pWanController->activeInterfaceIdx));
         return STATE_PARALLEL_SCAN_POLICY_ERROR;
@@ -885,7 +887,8 @@ static WcPsPolicyState_t State_SelectedInterfaceUp (WanMgr_Policy_Controller_t *
 
     if(pActiveInterface->VirtIfChanged == TRUE)
     {
-        if(WanMgr_StartWanVISM(pWanController->activeInterfaceIdx, WAN_IFACE_SELECTED) != 0)
+        CcspTraceInfo(("%s %d: Starting InterfaceStateMachine. Selection.Status=%d\n", __FUNCTION__, __LINE__, pActiveInterface->Selection.Status));
+        if(WanMgr_StartWanVISM(pWanController->activeInterfaceIdx, (pActiveInterface->Selection.Status == WAN_IFACE_ACTIVE )?WAN_IFACE_ACTIVE:WAN_IFACE_SELECTED) != 0)
         {
             CcspTraceError(("%s %d: Failed to start WAN for interface %d \n", __FUNCTION__, __LINE__, pWanController->activeInterfaceIdx));
             return STATE_PARALLEL_SCAN_POLICY_ERROR;


### PR DESCRIPTION
Key Changes:
wanmgr_policy_auto_impl.c

The log message for starting the virtual InterfaceStateMachine now includes Selection.Status. The call to WanMgr_StartWanVISM now passes WAN_IFACE_ACTIVE if Selection.Status is WAN_IFACE_ACTIVE, otherwise it passes WAN_IFACE_SELECTED. wanmgr_policy_parallel_scan_impl.c

Added a log message before starting the InterfaceStateMachine, showing Selection.Status. The call to WanMgr_StartWanVISM now conditionally passes WAN_IFACE_ACTIVE or WAN_IFACE_SELECTED based on Selection.Status. Similar logging and conditional parameter changes were made in another function when handling virtual interface changes.