### PR TITLE
RDKB-61845: In telemetry2_0 Event markers are assigned without component name

### DIFF
--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -324,12 +324,17 @@ int main(int argc, char* argv[])
         fputs(cmd, fd);
         fclose(fd);
     }
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
     CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
     t2_init("wanmanager");
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
     CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
 #endif
-
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif    
 #ifdef INCLUDE_BREAKPAD
     breakpad_ExceptionHandler();
 #else
@@ -347,6 +352,9 @@ int main(int argc, char* argv[])
     signal(SIGQUIT, sig_handler);
     signal(SIGHUP, sig_handler);
 #endif //INCLUDE_BREAKPAD
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif
 
     cmd_dispatch('e');
 #ifdef _COSA_SIM_
@@ -360,6 +368,9 @@ int main(int argc, char* argv[])
         fprintf(stderr, "Cdm_Init: %s\n", Cdm_StrError(err));
         exit(1);
     }
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif
 
 #ifdef ENABLE_SD_NOTIFY
     sd_notifyf(0, "READY=1\n"
@@ -368,6 +379,9 @@ int main(int argc, char* argv[])
 
     CcspTraceInfo(("RDKB_SYSTEM_BOOT_UP_LOG : wanmanager sd_notify Called\n"));
 #endif //ENABLE_SD_NOTIFY
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif
 
     /* Inform Webconfig framework if component is coming after crash */
     check_component_crash("/tmp/wanmanager_initialized");
@@ -377,6 +391,9 @@ int main(int argc, char* argv[])
     {
        close(fd_ret);
     }
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif
 
     //CORE INT
     WanMgr_Core_Init();
@@ -388,6 +405,10 @@ int main(int argc, char* argv[])
     //CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
     //t2_init(COMPONENT_NAME_WANMANAGER);
 #endif
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif
+    
     if ( bRunAsDaemon )
     {
         //MAIN THREAD
@@ -402,6 +423,9 @@ int main(int argc, char* argv[])
             cmd_dispatch(cmdChar);
         }
     }
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif
 
 
     //CORE FINALISE
@@ -414,10 +438,17 @@ int main(int argc, char* argv[])
     exit(1);
     }
 
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif
     ssp_cancel();
 
     //DATA DELETE
     WanMgr_Data_Delete();
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+#endif
+    
     return 0;
 }
 

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -385,7 +385,7 @@ int main(int argc, char* argv[])
     WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
     CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
-    t2_init(COMPONENT_NAME_WANMANAGER);
+    t2_init("wanmanager");
     CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
 #endif
     

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -289,11 +289,6 @@ int main(int argc, char* argv[])
     read_capability(&appcaps);
     clear_caps(&appcaps); 
 
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
-    t2_init("wanmanager");
-    CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
-#endif    
     for (idx = 1; idx < argc; idx++)
     {
         if ( (strcmp(argv[idx], "-subsys") == 0) )
@@ -329,6 +324,11 @@ int main(int argc, char* argv[])
         fputs(cmd, fd);
         fclose(fd);
     }
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
+    t2_init("wanmanager");
+    CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
+#endif
 
 #ifdef INCLUDE_BREAKPAD
     breakpad_ExceptionHandler();

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -380,7 +380,7 @@ int main(int argc, char* argv[])
 
     WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
-    t2_init("wanmanager");
+    t2_init(COMPONENT_NAME_WANMANAGER);
 #endif
     if ( bRunAsDaemon )
     {
@@ -412,7 +412,7 @@ int main(int argc, char* argv[])
 
     //DATA DELETE
     WanMgr_Data_Delete();
-//    t2_uninit();
+    t2_uninit();
     return 0;
 }
 

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -324,17 +324,11 @@ int main(int argc, char* argv[])
         fputs(cmd, fd);
         fclose(fd);
     }
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
-    t2_init("wanmanager");
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-    CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
+//    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
+//    t2_init("wanmanager");
+//    CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
 #endif
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-#endif    
 #ifdef INCLUDE_BREAKPAD
     breakpad_ExceptionHandler();
 #else
@@ -352,9 +346,6 @@ int main(int argc, char* argv[])
     signal(SIGQUIT, sig_handler);
     signal(SIGHUP, sig_handler);
 #endif //INCLUDE_BREAKPAD
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-#endif
 
     cmd_dispatch('e');
 #ifdef _COSA_SIM_
@@ -368,9 +359,6 @@ int main(int argc, char* argv[])
         fprintf(stderr, "Cdm_Init: %s\n", Cdm_StrError(err));
         exit(1);
     }
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-#endif
 
 #ifdef ENABLE_SD_NOTIFY
     sd_notifyf(0, "READY=1\n"
@@ -379,9 +367,6 @@ int main(int argc, char* argv[])
 
     CcspTraceInfo(("RDKB_SYSTEM_BOOT_UP_LOG : wanmanager sd_notify Called\n"));
 #endif //ENABLE_SD_NOTIFY
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-#endif
 
     /* Inform Webconfig framework if component is coming after crash */
     check_component_crash("/tmp/wanmanager_initialized");
@@ -391,9 +376,6 @@ int main(int argc, char* argv[])
     {
        close(fd_ret);
     }
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-#endif
 
     //CORE INT
     WanMgr_Core_Init();
@@ -402,11 +384,9 @@ int main(int argc, char* argv[])
 
     WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
-    //CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
-    //t2_init(COMPONENT_NAME_WANMANAGER);
-#endif
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
+    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
+    t2_init(COMPONENT_NAME_WANMANAGER);
+    CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
 #endif
     
     if ( bRunAsDaemon )
@@ -423,10 +403,6 @@ int main(int argc, char* argv[])
             cmd_dispatch(cmdChar);
         }
     }
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-#endif
-
 
     //CORE FINALISE
     WanMgr_Core_Finalise();
@@ -438,16 +414,10 @@ int main(int argc, char* argv[])
     exit(1);
     }
 
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-#endif
     ssp_cancel();
 
     //DATA DELETE
     WanMgr_Data_Delete();
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: %d KAVYA\n",__FUNCTION__,__LINE__));
-#endif
     
     return 0;
 }

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -412,7 +412,7 @@ int main(int argc, char* argv[])
 
     //DATA DELETE
     WanMgr_Data_Delete();
-    t2_uninit();
+//    t2_uninit();
     return 0;
 }
 

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -380,7 +380,7 @@ int main(int argc, char* argv[])
 
     WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
-    t2_init(COMPONENT_NAME_WANMANAGER);
+    t2_init("wanmanager");
 #endif
     if ( bRunAsDaemon )
     {
@@ -412,7 +412,7 @@ int main(int argc, char* argv[])
 
     //DATA DELETE
     WanMgr_Data_Delete();
-
+    t2_uninit();
     return 0;
 }
 

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -289,6 +289,11 @@ int main(int argc, char* argv[])
     read_capability(&appcaps);
     clear_caps(&appcaps); 
 
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
+    t2_init("wanmanager");
+    CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
+#endif    
     for (idx = 1; idx < argc; idx++)
     {
         if ( (strcmp(argv[idx], "-subsys") == 0) )
@@ -381,7 +386,7 @@ int main(int argc, char* argv[])
     WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
     //CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
-    //t2_init("wanmanager");
+    //t2_init(COMPONENT_NAME_WANMANAGER);
 #endif
     if ( bRunAsDaemon )
     {

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -380,7 +380,7 @@ int main(int argc, char* argv[])
 
     WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
-    t2_init(COMPONENT_NAME_WANMANAGER);
+    t2_init(WAN_COMPONENT_NAME);
 #endif
     if ( bRunAsDaemon )
     {
@@ -412,7 +412,6 @@ int main(int argc, char* argv[])
 
     //DATA DELETE
     WanMgr_Data_Delete();
-    t2_uninit();
     return 0;
 }
 

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -380,8 +380,8 @@ int main(int argc, char* argv[])
 
     WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
-    t2_init("wanmanager");
+    //CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
+    //t2_init("wanmanager");
 #endif
     if ( bRunAsDaemon )
     {

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -325,10 +325,9 @@ int main(int argc, char* argv[])
         fclose(fd);
     }
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
-//    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
-//    t2_init("wanmanager");
-//    CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
+    t2_init("wanmanager");
 #endif
+
 #ifdef INCLUDE_BREAKPAD
     breakpad_ExceptionHandler();
 #else
@@ -383,11 +382,6 @@ int main(int argc, char* argv[])
     waitUntilSystemReady();
 
     WanMgrDmlWanWebConfigInit();
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
-    t2_init("wanmanager");
-    CcspTraceInfo(("%s: Called t2_init(wanmanager)\n",__FUNCTION__));
-#endif
     
     if ( bRunAsDaemon )
     {

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -380,7 +380,8 @@ int main(int argc, char* argv[])
 
     WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
-    t2_init(WAN_COMPONENT_NAME);
+    CcspTraceInfo(("%s: Calling t2_init(wanmanager)\n",__FUNCTION__));
+    t2_init("wanmanager");
 #endif
     if ( bRunAsDaemon )
     {

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -1,6 +1,7 @@
 #include "wanmgr_t2_telemetry.h"
 #include "wanmgr_rdkbus_utils.h"
 
+#define BUFFER_LENGTH_256 256
 static char MarkerArguments[BUFFER_LENGTH_256] = {0};
 
 /*append api appends key value in pairs, separated by DELIMITER*/

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -1,7 +1,8 @@
 #include "wanmgr_t2_telemetry.h"
 #include "wanmgr_rdkbus_utils.h"
 
-#define BUFFER_LENGTH_256 256
+#define BUFFER_LENGTH_256     256
+#define T2_COMPONENT_READY    "/tmp/.t2ReadyToReceiveEvents"
 static char MarkerArguments[BUFFER_LENGTH_256] = {0};
 
 /*append api appends key value in pairs, separated by DELIMITER*/
@@ -199,9 +200,17 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
         default:
             ;
     }
-    t2_init("eRT.com.cisco.spvtg.ccsp.wanmanager");
-    t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
+/*    CcspTraceInfo(("%s: Check for T2_COMPONENT_READY.\n",__FUNCTION__));
+    if(access( T2_COMPONENT_READY, F_OK) == -1) 
+    {
+	CcspTraceInfo(("%s: T2 component not ready to recieve events, return.\n",__FUNCTION__));
+        return ANSC_STATUS_SUCCESS;
+    }
+    else
+    {*/
+	CcspTraceInfo(("%s: Calling t2_event_s().\n",__FUNCTION__));
+        t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
+//    }
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
-    t2_uninit();
     return ANSC_STATUS_SUCCESS;
 }

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -1,8 +1,6 @@
 #include "wanmgr_t2_telemetry.h"
 #include "wanmgr_rdkbus_utils.h"
 
-#define BUFFER_LENGTH_256     256
-#define T2_COMPONENT_READY    "/tmp/.t2ReadyToReceiveEvents"
 static char MarkerArguments[BUFFER_LENGTH_256] = {0};
 
 /*append api appends key value in pairs, separated by DELIMITER*/
@@ -200,14 +198,6 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
         default:
             ;
     }
-/*    CcspTraceInfo(("%s: Check for T2_COMPONENT_READY.\n",__FUNCTION__));
-    if(access( T2_COMPONENT_READY, F_OK) == -1) 
-    {
-	CcspTraceInfo(("%s: T2 component not ready to recieve events, return.\n",__FUNCTION__));
-        return ANSC_STATUS_SUCCESS;
-    }
-    else
-    {*/
 //    t2_init("wanmanager");
     CcspTraceInfo(("%s: Calling t2_event_s().\n",__FUNCTION__));
     t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -24,6 +24,7 @@ static void wanmgr_telemetry_append_key_value(char* key, const char* value)
  * gets the data required to send to T2 marker*/
 ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
 {
+    t2_init("wanmanagerT2");
     DML_WAN_IFACE *pIntf = Marker->pInterface;
     DML_VIRTUAL_IFACE *pVirtIntf = Marker->pVirtInterface;
     memset(MarkerArguments,0,sizeof(MarkerArguments));
@@ -211,6 +212,7 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
 	CcspTraceInfo(("%s: Calling t2_event_s().\n",__FUNCTION__));
         t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
 //    }
+    t2_uninit();
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
     return ANSC_STATUS_SUCCESS;
 }

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -199,12 +199,7 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
         default:
             ;
     }
-//    t2_init("wanmanager");
-    CcspTraceInfo(("%s: Calling t2_event_s().\n",__FUNCTION__));
     t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
-    CcspTraceInfo(("%s: Called t2_event_s().\n",__FUNCTION__));
-//    t2_uninit();
-
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
     return ANSC_STATUS_SUCCESS;
 }

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -199,7 +199,7 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
         default:
             ;
     }
-    t2_init("wan-manager");
+    t2_init("eRT.com.cisco.spvtg.ccsp.wanmanager");
     t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
     t2_uninit();

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -199,7 +199,7 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
         default:
             ;
     }
-    t2_init("wan-manager");
+    t2_init("wanmanager");
     t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
     t2_uninit();

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -199,7 +199,7 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
         default:
             ;
     }
-    t2_init("wanmanager");
+    t2_init("wan-manager");
     t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
     t2_uninit();

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -208,10 +208,12 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
     }
     else
     {*/
-    t2_init("wanmanager");
-	CcspTraceInfo(("%s: Calling t2_event_s().\n",__FUNCTION__));
-        t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
-    t2_uninit();
+//    t2_init("wanmanager");
+    CcspTraceInfo(("%s: Calling t2_event_s().\n",__FUNCTION__));
+    t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
+    CcspTraceInfo(("%s: Called t2_event_s().\n",__FUNCTION__));
+//    t2_uninit();
+
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
     return ANSC_STATUS_SUCCESS;
 }

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -199,7 +199,9 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
         default:
             ;
     }
+    t2_init("wan-manager");
     t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
+    t2_uninit();
     return ANSC_STATUS_SUCCESS;
 }

--- a/source/WanManager/wanmgr_t2_telemetry.c
+++ b/source/WanManager/wanmgr_t2_telemetry.c
@@ -24,7 +24,6 @@ static void wanmgr_telemetry_append_key_value(char* key, const char* value)
  * gets the data required to send to T2 marker*/
 ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
 {
-    t2_init("wanmanagerT2");
     DML_WAN_IFACE *pIntf = Marker->pInterface;
     DML_VIRTUAL_IFACE *pVirtIntf = Marker->pVirtInterface;
     memset(MarkerArguments,0,sizeof(MarkerArguments));
@@ -209,9 +208,9 @@ ANSC_STATUS wanmgr_process_T2_telemetry_event(WanMgr_Telemetry_Marker_t *Marker)
     }
     else
     {*/
+    t2_init("wanmanager");
 	CcspTraceInfo(("%s: Calling t2_event_s().\n",__FUNCTION__));
         t2_event_s(WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments);
-//    }
     t2_uninit();
     CcspTraceInfo(("%s %d: Successfully sent Telemetry event [%s] with arguments = [%s].\n",__FUNCTION__, __LINE__,WanMgr_TelemetryEventStr[Marker->enTelemetryMarkerID],MarkerArguments));
     return ANSC_STATUS_SUCCESS;


### PR DESCRIPTION
Reason for change: t2_init should be called with simple name and at right place.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1